### PR TITLE
fix:修复断开蓝牙后点击stopDeviceScan按钮闪退的问题

### DIFF
--- a/harmony/rn_bleplx/src/main/ets/BleModule.ts
+++ b/harmony/rn_bleplx/src/main/ets/BleModule.ts
@@ -183,8 +183,11 @@ export class BleClientManager {
    */
   public stopDeviceScan(): Promise<void> {
     try {
-      ble.off("BLEDeviceFind");
-      ble.stopBLEScan();
+      let state = access.getState();
+      if(state === access.BluetoothState.STATE_ON){
+        ble.off("BLEDeviceFind");
+        ble.stopBLEScan();
+      }
       return Promise.resolve();
     } catch (err) {
       Logger.error('errCode: ' + (err as BusinessError).code + ', errMessage: ' + (err as BusinessError).message);


### PR DESCRIPTION
# Summary

- [fix:修复断开蓝牙后点击stopDeviceScan按钮闪退的问题](https://github.com/react-native-oh-library/react-native-ble-plx/commit/1f00681b06acb80f96bf6c6b7d8f8448a8aae78f)

## Test Plan
<img width="1972" height="851" alt="image" src="https://github.com/user-attachments/assets/f34639a4-00e5-4554-b9a5-bbd2865a9307" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
